### PR TITLE
Made ClustENM a subclass of Ensemble

### DIFF
--- a/prody/dynamics/signature.py
+++ b/prody/dynamics/signature.py
@@ -1467,10 +1467,10 @@ def showSignatureOverlaps(mode_ensemble, **kwargs):
         overlap_triu = overlaps[:, :, r, c]
 
         if std:
-            stdV = overlap_triu.std(axis=-1).std(axis=-1)
+            stdV = overlap_triu.std(axis=-1)
             show = showMatrix(stdV)
         else:
-            meanV = overlap_triu.mean(axis=-1).mean(axis=-1)
+            meanV = overlap_triu.mean(axis=-1)
             show = showMatrix(meanV)
     
     return show


### PR DESCRIPTION
Now the user can either index `ClustENM` by `clustenm[3]` which picks the third conformation (presumably the 2nd conformation in the first generation) or equivalently with generation No. and index, `clustenm[1, 1]`. The indexing supports slicing too, for example:

```
clustenm[:, 3]  # select the third conformation for every generation (skip if a particular generation doesn't have three conformations)
clustenm[2, :] # select all the conformations in the 2nd generation
```
