### PR TITLE
Derived ClustENM from Ensemble

### DIFF
--- a/prody/dynamics/__init__.py
+++ b/prody/dynamics/__init__.py
@@ -300,3 +300,7 @@ __all__.extend(adaptive.__all__)
 from . import clustenm
 from .clustenm import *
 __all__.extend(clustenm.__all__)
+
+# workaround for circular dependency to accommodate original design style 
+from prody.ensemble import functions
+functions.ClustENM = ClustENM

--- a/prody/dynamics/clustenm.py
+++ b/prody/dynamics/clustenm.py
@@ -568,7 +568,7 @@ class ClustENM(Ensemble):
         
         keys = self._getData('key')
         n_confs = 0
-        for g, i in keys:
+        for g, _ in keys:
             if g == gen:
                 n_confs += 1
         return n_confs
@@ -580,7 +580,7 @@ class ClustENM(Ensemble):
         if self._indexer is None:
             keys = self._getData('key')
             entries = [[] for _ in range(self.numGenerations())]
-            for i, (gen, idx) in enumerate(keys):
+            for i, (gen, _) in enumerate(keys):
                 entries[gen].append(i)
             
             n_conf_per_gen = np.max([len(entry) for entry in entries])
@@ -750,9 +750,9 @@ class ClustENM(Ensemble):
             conformers = np.array(conformers)[idx]
 
             if self._outlier:
-                idx = np.logical_not(self._outliers(potentials))
+                idx = np.logical_not(self._outliers(pots))
             else:
-                idx = np.full(potentials.size, True, dtype=bool)
+                idx = np.full(pots.size, True, dtype=bool)
 
             sizes.append(weights[idx])
             potentials.append(pots[idx])

--- a/prody/dynamics/clustenm.py
+++ b/prody/dynamics/clustenm.py
@@ -762,9 +762,6 @@ class ClustENM(Ensemble):
         LOGGER.timeit('_clustenm_ens')
         LOGGER.info('Creating an ensemble of conformers ...')
 
-        self.potentials = potentials
-        self.keys = keys
-        self.sizes = sizes
         self._build(conformers, keys, potentials, sizes)
         LOGGER.report('Ensemble was created in %.2fs.', label='_clustenm_ens')
 
@@ -804,8 +801,3 @@ class ClustENM(Ensemble):
                 f.write(f'platform = %s\n'%self._platform)
             else:
                 f.write(f'platform = Default\n')
-
-        with open(f'{title}_potentials.pkl', 'wb') as f:
-            pickle.dump(self.getPotentials(), f, pickle.HIGHEST_PROTOCOL)
-        with open(f'{title}_sizes.pkl', 'wb') as f:
-            pickle.dump(self.getSizes(), f, pickle.HIGHEST_PROTOCOL)

--- a/prody/dynamics/clustenm.py
+++ b/prody/dynamics/clustenm.py
@@ -331,12 +331,12 @@ class ClustENM(Ensemble):
 
             return np.nan, np.full_like(arg, np.nan)
 
-    def _sample_v1(self, arg):
+    def _sample_v1(self, conf):
 
         # arg: conf idx
 
         tmp = self._atoms.copy()
-        tmp.setCoords(self._conformers[self._cycle - 1][arg])
+        tmp.setCoords(conf)
         ca = tmp.ca
 
         anm_ca = ANM()
@@ -369,12 +369,9 @@ class ClustENM(Ensemble):
 
         return r
 
-    def _sample(self, arg):
-
-        # arg: conf idx
-
+    def _sample(self, conf):
         tmp = self._atoms.copy()
-        tmp.setCoords(self._conformers[self._cycle - 1][arg])
+        tmp.setCoords(conf)
         ca = tmp.ca
 
         anm_ca = ANM()

--- a/prody/ensemble/conformation.py
+++ b/prody/ensemble/conformation.py
@@ -71,6 +71,24 @@ class Conformation(object):
         else:
             return ensemble._getWeights()[indices]
 
+    def getData(self, label):
+        """Returns a copy of the data array associated with *label*, or **None**
+        if such data is not present."""
+
+        data = self._ensemble.getData(label)
+        if data is not None:
+            data = data[self._index]
+        return data
+
+    def _getData(self, label):
+        """Returns data array associated with *label*, or **None** if such data
+        is not present."""
+
+        data = self._ensemble._getData(label)
+        if data is not None:
+            data = data[self._index]
+        return data
+
     def getEnsemble(self):
         """Returns the ensemble that this conformation belongs to."""
 

--- a/prody/ensemble/ensemble.py
+++ b/prody/ensemble/ensemble.py
@@ -54,16 +54,16 @@ class Ensemble(object):
     def __repr__(self):
 
         if self._indices is None:
-            return ('<Ensemble: {0} ({1} conformations; {2} atoms)>'
-                    ).format(self._title, len(self), self._n_atoms)
+            return ('<{0}: {1} ({2} conformations; {3} atoms)>'
+                    ).format(self.__class__.__name__, self.getTitle(), len(self), self._n_atoms)
         else:
-            return ('<Ensemble: {0} ({1} conformations; selected {2} of '
-                    '{3} atoms)>').format(self._title, len(self),
+            return ('<{0}: {1} ({2} conformations; selected {3} of '
+                    '{4} atoms)>').format(self.__class__.__name__, self.getTitle(), len(self),
                                           self.numSelected(), self._n_atoms)
 
     def __str__(self):
 
-        return 'Ensemble {0}'.format(self._title)
+        return 'Ensemble {0}'.format(self.getTitle())
 
     def __len__(self):
 
@@ -86,14 +86,15 @@ class Ensemble(object):
             return self.getConformation(index)
 
         elif isinstance(index, slice):
-            ens = Ensemble('{0} ({1[0]}:{1[1]}:{1[2]})'.format(
-                                self._title, index.indices(len(self))))
-            ens.setCoords(copy(self._coords))
+            ens = type(self)('{0} ({1[0]}:{1[1]}:{1[2]})'.format(
+                                self.getTitle(), index.indices(len(self))))
+            if self._coords is not None:
+                ens.setCoords(self._coords.copy())
         
+            ens.addCoordset(self._confs[index].copy())
+
             for key in self._data.keys():
                 ens._data[key] = self._data[key][index].copy()
-
-            ens.addCoordset(self._confs[index].copy())
             if self._weights is not None:
                 ens.setWeights(self._weights.copy())
             
@@ -102,11 +103,12 @@ class Ensemble(object):
             return ens
 
         elif isinstance(index, (list, ndarray)):
-            ens = Ensemble('{0}'.format(self._title))
-            ens.setCoords(copy(self._coords))
+            ens = type(self)('{0}'.format(self.getTitle()))
+            if self._coords is not None:
+                ens.setCoords(self._coords.copy())
+            ens.addCoordset(self._confs[index].copy())
             for key in self._data.keys():
                 ens._data[key] = self._data[key][index].copy()
-            ens.addCoordset(self._confs[index].copy())
             if self._weights is not None:
                 ens.setWeights(self._weights.copy())
 
@@ -136,7 +138,7 @@ class Ensemble(object):
         if other._confs is not None:
             ensemble.addCoordset(other._confs.copy())
 
-        all_keys = list(self._data.keys()) + list(other._data.keys())
+        all_keys = set(list(self._data.keys()) + list(other._data.keys()))
         for key in all_keys:
             if key in self._data and key in other._data:
                 self_data = self._data[key]
@@ -392,13 +394,21 @@ class Ensemble(object):
                 self._weights = ones((self._n_atoms, 1), dtype=float)
             self._weights[self._indices, :] = weights    
 
-    def addCoordset(self, coords):
-        """Add coordinate set(s) to the ensemble.  *coords* must be a Numpy
-        array with suitable data type, shape and dimensionality, or an object
-        with :meth:`getCoordsets` method."""
+    def addCoordset(self, coords, **kwargs):
+        """Add coordinate set(s) to the ensemble.  
+        
+        :arg coords: must be a :class:`~numpy.ndarray` with suitable data type, 
+                     shape and dimensionality, or an object with :meth:`getCoordsets` method. 
+                     
+        :kwarg data: associated data to be added along with *coords*.
+        :type data: dict   
+        """
 
         n_atoms = self._n_atoms
         n_select = self.numSelected()
+
+        adddata = kwargs.pop('data', {})
+
         try:
             if self._coords is not None:
                 if isinstance(coords, Ensemble):
@@ -432,6 +442,7 @@ class Ensemble(object):
                 raise TypeError('coords must be a numpy array or an object '
                                 'with `getCoords` method')
 
+        # update coordinates
         if coords.ndim == 2:
             n_nodes, _ = coords.shape
             coords = coords.reshape((1, n_nodes, 3))
@@ -451,12 +462,28 @@ class Ensemble(object):
             self._confs = coords
         else:
             self._confs = concatenate((self._confs, coords), axis=0)
-        self._n_csets += n_confs
+        
+        # appending new data
+        all_keys = set(list(self._data.keys()) + list(adddata.keys()))
 
-        for key in self._data:
-            data = self._data[key]
-            def_data = zeros(n_confs, dtype=data.dtype)
-            self._data[key] = concatenate((data, def_data), axis=0)
+        for key in all_keys:
+            if key in self._data:
+                data = self._data[key]
+                if key not in adddata:
+                    shape = (n_confs, *data.shape[1:])
+                    newdata = zeros(shape, dtype=data.dtype)
+                else:
+                    newdata = asarray(adddata[key])
+                    if newdata.shape[0] != n_confs:
+                        raise ValueError('the length of data["%s"] does not match that of coords'%key)
+            else:
+                newdata = asarray(adddata[key])
+                shape = (self._n_csets, *newdata.shape[1:])
+                data = zeros(shape, dtype=newdata.dtype)
+            self._data[key] = concatenate((data, newdata), axis=0)
+
+        # update the number of coordinate sets
+        self._n_csets += n_confs
 
     def getCoordsets(self, indices=None, selected=True):
         """Returns a copy of coordinate set(s) at given *indices*, which may be

--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -39,6 +39,11 @@ def saveEnsemble(ensemble, filename=None, **kwargs):
     if isinstance(ensemble, PDBEnsemble):
         attr_list.append('_labels')
         attr_list.append('_trans')
+    if isinstance(ensemble, ClustENM):
+        attr_list.extend(['_ph', '_cutoff', '_n_modes', '_n_confs', '_rmsd', '_n_gens', 
+                          '_sim', '_threshold', '_maxclust', '_temp', '_t_steps', '_outlier', 
+                          '_mzscore', '_v1', '_platform', '_n_ca'])
+
     if filename is None:
         filename = ensemble.getTitle().replace(' ', '_')
     attr_dict = {}
@@ -59,6 +64,8 @@ def saveEnsemble(ensemble, filename=None, **kwargs):
         msa = dict_['_msa']
         if msa is not None:
             attr_dict['_msa'] = np.array([msa, None])
+
+    attr_dict['_type'] = ensemble.__class__.__name__
 
     if filename.endswith('.ens'):
         filename += '.npz'
@@ -86,53 +93,42 @@ def loadEnsemble(filename, **kwargs):
     else:
         weights = None  
 
-    isPDBEnsemble = False
+    # backward compatibility
+    try:
+        type_ = attr_dict['_type']
+    except KeyError:
+        if weights is not None and weights.ndim == 3:
+            type_ = 'PDBEnsemble'
+        else:
+            type_ = 'Ensemble'
 
     try:
         title = attr_dict['_title']
     except KeyError:
-        title = attr_dict['_name']
+        if type_ == 'ClustENM':
+            title = None
+        else:
+            title = attr_dict['_name']
+            
     if isinstance(title, np.ndarray):
-        title = np.asarray(title, dtype=str)
-    title = str(title)
+        title = title.item()
 
-    if weights is not None and weights.ndim == 3:
-        isPDBEnsemble = True
+    if not isinstance(title, str) and title is not None:
+        try:
+            title = title.decode()
+        except AttributeError:
+            title = str(title)
+
+    if type_ == 'PDBEnsemble':
         ensemble = PDBEnsemble(title)
+    elif type_ == 'ClustENM':
+        ensemble = ClustENM(title)
     else:
         ensemble = Ensemble(title)
 
     ensemble.setCoords(attr_dict['_coords'])
-    if '_atoms' in attr_dict:
-        atoms = attr_dict['_atoms'][0]
-
-        if isinstance(atoms, AtomGroup):
-            data = atoms._data
-        else:
-            data = atoms._ag._data
-        
-        for key in data:
-            arr = data[key]
-            char = arr.dtype.char
-            if char in 'SU' and char != DTYPE:
-                arr = arr.astype(str)
-                data[key] = arr
-            
-    else:
-        atoms = None
-    ensemble.setAtoms(atoms)
-
-    if '_indices' in attr_dict:
-        indices = attr_dict['_indices']
-    else:
-        indices = None
-    ensemble._indices = indices
-
-    if '_data' in attr_dict:
-        ensemble._data = attr_dict['_data'][0]
-
-    if isPDBEnsemble:
-        confs = attr_dict['_confs']
+    confs = attr_dict['_confs']
+    if type_ == 'PDBEnsemble':
         ensemble.addCoordset(confs, weights)
         if '_identifiers' in attr_dict.files:
             ensemble._labels = list(attr_dict['_identifiers'])
@@ -150,9 +146,47 @@ def loadEnsemble(filename, **kwargs):
         if '_msa' in attr_dict.files:
             ensemble._msa = attr_dict['_msa'][0]
     else:
-        ensemble.addCoordset(attr_dict['_confs'])
+        if type_ == 'ClustENM':
+            attrs = ['_ph', '_cutoff', '_n_modes', '_n_confs', '_rmsd', '_n_gens', 
+                    '_sim', '_threshold', '_maxclust', '_temp', '_t_steps', '_outlier', 
+                    '_mzscore', '_v1', '_platform', '_n_ca']
+            for attr in attrs:
+                if attr in attr_dict:
+                    val = attr_dict[attr]
+                    if len(val.shape) == 0:
+                        val = val.item()
+                    ensemble.__dict__[attr] = val
+        ensemble.addCoordset(confs)
         if weights is not None:
             ensemble.setWeights(weights)
+
+    if '_atoms' in attr_dict:
+        atoms = attr_dict['_atoms'][0]
+
+        if isinstance(atoms, AtomGroup):
+            data = atoms._data
+        else:
+            data = atoms._ag._data
+        
+        for key in data:
+            arr = data[key]
+            char = arr.dtype.char
+            if char in 'SU' and char != DTYPE:
+                arr = arr.astype(str)
+                data[key] = arr
+    else:
+        atoms = None
+    ensemble.setAtoms(atoms)
+
+    if '_indices' in attr_dict:
+        indices = attr_dict['_indices']
+    else:
+        indices = None
+    ensemble._indices = indices
+
+    if '_data' in attr_dict:
+        ensemble._data = attr_dict['_data'][0]
+
     return ensemble
 
 

--- a/prody/ensemble/pdbensemble.py
+++ b/prody/ensemble/pdbensemble.py
@@ -379,6 +379,11 @@ class PDBEnsemble(Ensemble):
             raise RuntimeError('_confs and _weights must be set or None at '
                                'the same time')
 
+        for key in self._data:
+            data = self._data[key]
+            def_data = zeros(n_repeats, dtype=data.dtype)
+            self._data[key] = concatenate((data, def_data), axis=0)
+
     def getMSA(self, indices=None, selected=True):
         """Returns an MSA of selected atoms."""
 


### PR DESCRIPTION
Now the user can either index `ClustENM` by `clustenm[3]` which picks the third conformation (presumably the 2nd conformation in the first generation) or equivalently with generation No. and index, `clustenm[1, 1]`. The indexing supports slicing too, for example:

```
clustenm[:, 3]  # select the third conformation for every generation (skip if a particular generation doesn't have three conformations)
clustenm[2, :] # select all the conformations in the 2nd generation
```
